### PR TITLE
fixed displaying warnings during building the project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 spynix: clear
-	@clang src/main.c src/cpu/cpu_info.c src/hlp/hlp_info.c src/net/net_info.c src/ram/ram_info.c src/rom/rom_info.c src/sys/sys_info.c -o spynix -W -ansi -pedantic
+	@clang src/main.c src/cpu/cpu_info.c src/hlp/hlp_info.c src/net/net_info.c src/ram/ram_info.c src/rom/rom_info.c src/sys/sys_info.c -o spynix -Wall -ansi -pedantic
 
 clear:
 	@rm -f spynix


### PR DESCRIPTION
### Description
- changed compiling flag in Makefile to fix displaying all warnings during building the project.

### Checklist
- [x] Code compiles correctly
- [x] Code is formatted using the correct coding style
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file
